### PR TITLE
Adjust teamleader.eu url to focus.teamleader.eu

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In the app type `yarn timesheets` Tasks you have configured in Timing will be sy
 ## References
 
 - [Timing App API docs](https://web.timingapp.com/docs/)
-- [Teamleader API docs](https://developer.teamleader.eu/)
+- [Teamleader API docs](https://developer.focus.teamleader.eu/)
 
 ---
 

--- a/src/teamleader.js
+++ b/src/teamleader.js
@@ -34,7 +34,7 @@ export default {
     log(`${chalk.yellow('Starting:')} Visit the following link...`);
 
     console.log(
-      chalk.magenta(`https://app.teamleader.eu/oauth2/authorize?${query}`)
+      chalk.magenta(`https://focus.teamleader.eu/oauth2/authorize?${query}`)
     );
 
     log(`Then copy the URL that you are redirected to. After that run...`);
@@ -47,7 +47,7 @@ export default {
       const { code } = JSON.parse(redirect_uri.split('?')[1]);
 
       const success = await axios.post(
-        'https://app.teamleader.eu/oauth2/access_token',
+        'https://focus.teamleader.eu/oauth2/access_token',
         {
           client_id: TEAMLEADER_CLIENT_ID,
           client_secret: TEAMLEADER_CLIENT_SECRET,
@@ -95,7 +95,7 @@ export default {
   },
 
   refresh: async () => {
-    const endpoint = 'https://app.teamleader.eu/oauth2/access_token';
+    const endpoint = 'https://focus.teamleader.eu/oauth2/access_token';
 
     try {
       const success = await axios.post(endpoint, {
@@ -141,7 +141,7 @@ export default {
   },
 
   endpoint: (resource, action) =>
-    resource && action && `https://api.teamleader.eu/${resource}.${action}`,
+    resource && action && `https://api.focus.teamleader.eu/${resource}.${action}`,
 
   getProjects: async () =>
     self.request(self.endpoint('projects', 'list'), 'GET', {


### PR DESCRIPTION
The Teamleader application has been renamed to Teamleader Focus, more info about this can be found [here](https://www.teamleader.eu/blog/new-names-teamleader-focus-orbit). This product name change also means that the application, api, marketplace, etc. have a new home under [focus.teamleader.eu](https://focus.teamleader.eu).

This PR changes the Teamleader URLs in this repo to point to [focus.teamleader.eu](https://focus.teamleader.eu). The switch to these new URLs isn't urgent though, the old URLs will remain available for some time.